### PR TITLE
Fix Core User initializer

### DIFF
--- a/Modules/Core/Sources/Core/Core.swift
+++ b/Modules/Core/Sources/Core/Core.swift
@@ -6,6 +6,25 @@ public struct User {
   public let email: String
   public let telephone: String
   public let avatarURL: String
+
+  /// Public memberwise initializer so other modules can instantiate `User`.
+  public init(
+    firstName: String,
+    lastName: String,
+    companyName: String,
+    position: String,
+    email: String,
+    telephone: String,
+    avatarURL: String
+  ) {
+    self.firstName = firstName
+    self.lastName = lastName
+    self.companyName = companyName
+    self.position = position
+    self.email = email
+    self.telephone = telephone
+    self.avatarURL = avatarURL
+  }
 }
 
 public struct GetProfileUseCase {


### PR DESCRIPTION
## Summary
- expose `User` initializer publicly so other modules can create users

## Testing
- `swift test -c release` within `Modules/Core`
- ❌ `swift test -c release` within `Modules/Profile` (fails to build on Linux)

------
https://chatgpt.com/codex/tasks/task_e_684d54e8eea08323baa76756e67b3648