### PR TITLE
Fix optional scope in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
-        args: [optional-scope]
+        args: [--optional-scope]
 
 # Swift formatting and linting (if tools are available)
 -   repo: local


### PR DESCRIPTION
## Summary
- use `--optional-scope` arg for the `conventional-pre-commit` hook

## Testing
- `swift test --verbose` in `Modules/Core`
- `swift test --verbose` in `Modules/Profile` *(fails: `Foundation/Foundation.h` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684d572dd7e48323b986081ce8aa0db5