### PR TITLE
Add HomeView with Swinject DI example

### DIFF
--- a/Bello/BelloApp.swift
+++ b/Bello/BelloApp.swift
@@ -1,4 +1,5 @@
 import Profile
+import Home
 import SwiftUI
 
 @main
@@ -14,7 +15,7 @@ struct BelloApp: App {
         }
 
         NavigationStack {
-          Text("Home")
+          HomeView()
         }
         .tabItem {
           Label("Home", systemImage: "house")

--- a/Modules/Home/Package.resolved
+++ b/Modules/Home/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "6b21a36ded27e6629b571753eceb97831ff7b52c7c4447f05409bd167155df62",
+  "pins" : [
+    {
+      "identity" : "swinject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Swinject/Swinject.git",
+      "state" : {
+        "revision" : "be9dbcc7b86811bc131539a20c6f9c2d3e56919f",
+        "version" : "2.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Modules/Home/Package.swift
+++ b/Modules/Home/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "Home",
+    platforms: [.iOS(.v16)],
+    products: [
+        .library(name: "Home", targets: ["Home"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.9.1")
+    ],
+    targets: [
+        .target(name: "Home", dependencies: ["Swinject"]),
+        .testTarget(name: "HomeTests", dependencies: ["Home"])
+    ]
+)

--- a/Modules/Home/Sources/Home/GreetingService.swift
+++ b/Modules/Home/Sources/Home/GreetingService.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public protocol GreetingService {
+    func greeting() -> String
+}
+
+public class DefaultGreetingService: GreetingService {
+    public init() {}
+    public func greeting() -> String {
+        "Hello from DI!"
+    }
+}

--- a/Modules/Home/Sources/Home/HomeView.swift
+++ b/Modules/Home/Sources/Home/HomeView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import Swinject
+
+public struct HomeView: View {
+    let container: Container
+    @StateObject var viewModel: HomeViewModel
+
+    public init() {
+        let container = Container()
+        container.register(GreetingService.self) { _ in DefaultGreetingService() }
+        self.container = container
+        _viewModel = StateObject(wrappedValue: HomeViewModel(container: container))
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            if viewModel.message.isEmpty {
+                ProgressView("Loading...")
+                    .onAppear { viewModel.loadGreeting() }
+            } else {
+                Text(viewModel.message)
+                    .font(.headline)
+            }
+        }
+        .navigationTitle("Home")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HomeView()
+    }
+}

--- a/Modules/Home/Sources/Home/HomeViewModel.swift
+++ b/Modules/Home/Sources/Home/HomeViewModel.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Combine
+import Swinject
+
+public class HomeViewModel: ObservableObject {
+    @Published public var message: String = ""
+    let greetingService: GreetingService
+
+    public init(container: Resolver) {
+        self.greetingService = container.resolve(GreetingService.self)!
+    }
+
+    public func loadGreeting() {
+        message = greetingService.greeting()
+    }
+}

--- a/Modules/Home/Tests/HomeTests.swift
+++ b/Modules/Home/Tests/HomeTests.swift
@@ -2,12 +2,17 @@ import XCTest
 import Swinject
 @testable import Home
 
+/// Mock greeting service for testing purposes
+final class MockGreetingService: GreetingService {
+    func greeting() -> String { "Test Greeting" }
+}
+
 final class HomeTests: XCTestCase {
     func testGreeting() throws {
         let container = Container()
-        container.register(GreetingService.self) { _ in DefaultGreetingService() }
+        container.register(GreetingService.self) { _ in MockGreetingService() }
         let viewModel = HomeViewModel(container: container)
         viewModel.loadGreeting()
-        XCTAssertEqual(viewModel.message, "Hello from DI!")
+        XCTAssertEqual(viewModel.message, "Test Greeting")
     }
 }

--- a/Modules/Home/Tests/HomeTests.swift
+++ b/Modules/Home/Tests/HomeTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Swinject
+@testable import Home
+
+final class HomeTests: XCTestCase {
+    func testGreeting() throws {
+        let container = Container()
+        container.register(GreetingService.self) { _ in DefaultGreetingService() }
+        let viewModel = HomeViewModel(container: container)
+        viewModel.loadGreeting()
+        XCTAssertEqual(viewModel.message, "Hello from DI!")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Bello
 This repository is a playground for exploring new ideas, techniques, and technologies in iOS development. Expect prototypes, quick experiments, and unconventional approaches using Swift, SwiftUI, Combine, and more. Code here is not production-ready — it’s meant for learning, testing, and pushing boundaries.
+
+## Dependency Injection Example
+
+The `Home` module demonstrates a simple use of **Swinject** for dependency injection. Launch the app and open the **Home** tab to see a greeting provided by a service resolved from a Swinject container.


### PR DESCRIPTION
## Summary
- add new `Home` Swift package that uses Swinject 2.9.1
- show a basic DI example with `HomeView`, `HomeViewModel`, and `GreetingService`
- display `HomeView` in the app's main tab
- document the DI example in the README

## Testing
- `swift test` in `Modules/Core`
- `swift test` in `Modules/Home` *(fails: no such module 'SwiftUI')*
- `swift test` in `Modules/Profile` *(fails to build SDWebImageSwiftUI)*

------
https://chatgpt.com/codex/tasks/task_e_687b655685948323a18d9efa8983e9ac